### PR TITLE
test: add a Retry helper for testing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,11 @@
 module utils
 
 go 1.19
+
+require github.com/stretchr/testify v1.8.1
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,17 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/test/testing.go
+++ b/test/testing.go
@@ -1,0 +1,17 @@
+package test
+
+import "time"
+
+// Retry will call 'fn' 'tries' times, waiting 'durationBetweenAttempts' between
+// each attempt, returning 'nil' the first time that 'fn' returns nil.  If 'nil'
+// is never returned, then the final error returned by 'fn' is returned.
+func Retry(tries int, durationBetweenAttempts time.Duration, fn func() error) (err error) {
+	for i := 1; i < tries; i++ {
+		err = fn()
+		if err == nil {
+			return nil
+		}
+		time.Sleep(durationBetweenAttempts)
+	}
+	return fn()
+}

--- a/test/testing_test.go
+++ b/test/testing_test.go
@@ -1,0 +1,96 @@
+package test
+
+import (
+	"errors"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestRetry probes the Retry function
+func TestRetry(t *testing.T) {
+	// Define Functions
+	returnError := errors.New("returned error")
+	errorFunc := func() error { return returnError }
+	successFunc := func() error { return nil }
+	intermittentFunc := func() error {
+		// Fail 25% of the time
+		if rand.Intn(4) == 2 {
+			return returnError
+		}
+		return nil
+	}
+
+	// Test Case: function always returns an error resulting in the full
+	// execution of tries.
+	//
+	// Set a retry timer for 500 Milliseconds, this should finish before the
+	// retry loop because the function always errors
+	retryTimer := time.NewTimer(500 * time.Millisecond)
+
+	// Set the Retry for 1 second total duration. We use milliseconds to
+	// ensure the func is called multiple times
+	err := Retry(10, 100*time.Millisecond, errorFunc)
+
+	// Verify the Retry took longer than the timer
+	select {
+	case <-retryTimer.C:
+	default:
+		t.Error("Retry executed faster than expected")
+	}
+
+	// Ensure we have the error returned from the errorFunc
+	assert.ErrorIs(t, err, returnError)
+
+	// Clean up, stop timer
+	retryTimer.Stop()
+
+	// Test Case: function returns nil immediately
+	//
+	// Set a retry timer for 1 second, this should not finish before the
+	// retry loop because the function returns nil
+	retryTimer = time.NewTimer(time.Second)
+
+	// Set the Retry for 10 second total duration, but we expect only one
+	// iteration to occur since the function returns nil
+	err = Retry(100, 100*time.Millisecond, successFunc)
+
+	// Verify the Retry finished before the timer
+	select {
+	case <-retryTimer.C:
+		t.Error("Retry executed slower than expected")
+	default:
+	}
+
+	// Ensure we have a nil error returned from the successFunc
+	assert.Nil(t, err)
+
+	// Clean up, stop timer
+	retryTimer.Stop()
+
+	// Test Case: function sometimes returns an error, but is ultimately
+	// expected to succeed
+	//
+	// Set a retry timer for 10 seconds, which is the same as the retry. The
+	// Retry should finish first
+	retryTimer = time.NewTimer(10 * time.Second)
+
+	// Set the Retry for 10 second total duration, we give it 100 tries and
+	// expect some to fail but ultimately it should return a nil
+	err = Retry(100, 100*time.Millisecond, intermittentFunc)
+
+	// Verify the Retry finished before the timer
+	select {
+	case <-retryTimer.C:
+		t.Error("Retry executed slower than expected")
+	default:
+	}
+
+	// Ensure we have a nil error returned from the successFunc
+	assert.Nil(t, err)
+
+	// Clean up, stop timer
+	retryTimer.Stop()
+}


### PR DESCRIPTION
# PULL REQUEST

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the apprioprate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

This PR creates a `Retry` helper for tests. It will retry a function `tries` times and wait `durationBetweenAttempts` before retrying.

Initially this was an issue created in the node repo (see issue linked below) but it is a helpful tool for all repos in testing. 

Closes https://github.com/celestiaorg/celestia-node/issues/1332

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
